### PR TITLE
#1 Control account registration

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,6 +1,7 @@
 en:
   site_settings:
     vivokey_openid_enabled: Enable VivoKey OpenID authentication. Customize user interface text <a href='%{base_path}/admin/customize/site_texts?q=js.login.vivokey'>here</a>
+    vivokey_openid_registration: "Enable new account registration"
     vivokey_openid_discovery_document: "VivoKey OpenID discovery document URL. Normally located at 'https://your.domain/.well-known/openid-configuration'"
     vivokey_openid_client_id: "VivoKey OpenID client ID"
     vivokey_openid_client_secret: "VivoKey OpenID client secret"
@@ -9,3 +10,5 @@ en:
     vivokey_openid_error_redirects: "If the callback error_reason contains the first parameter, the user will be redirected to the URL in the second parameter"
     vivokey_openid_allow_association_change: "Allow users to disconnect and reconnect their Discourse accounts from the VivoKey OpenID provider"
     vivokey_openid_verbose_logging: "Log detailed VivoKey OpenID authentication information to `/logs`. Keep this disabled during normal use."
+  vivokey_openid:
+    registration_not_allowed: "Account registration via VivoKey OpenID is not allowed."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,8 @@
 plugins:
   vivokey_openid_enabled:
     default: false
+  vivokey_openid_registration:
+    default: false
   vivokey_openid_discovery_document:
     default: ""
   vivokey_openid_client_id:

--- a/lib/omniauth_vivokey_open_id.rb
+++ b/lib/omniauth_vivokey_open_id.rb
@@ -123,7 +123,8 @@ module ::OmniAuth
             verify_sub: false,
             verify_expiration: true,
             verify_not_before: true,
-            verify_iat: true,
+            # TODO: set back to true
+            verify_iat: false,
             verify_jti: false
           )
           verbose_log("Verified JWT\n\n#{decoded.to_yaml}")

--- a/lib/omniauth_vivokey_open_id.rb
+++ b/lib/omniauth_vivokey_open_id.rb
@@ -123,8 +123,7 @@ module ::OmniAuth
             verify_sub: false,
             verify_expiration: true,
             verify_not_before: true,
-            # TODO: set back to true
-            verify_iat: false,
+            verify_iat: true,
             verify_jti: false
           )
           verbose_log("Verified JWT\n\n#{decoded.to_yaml}")

--- a/lib/vivo_key_authenticator.rb
+++ b/lib/vivo_key_authenticator.rb
@@ -1,0 +1,61 @@
+require_relative "omniauth_vivokey_open_id"
+
+class VivoKeyAuthenticator < Auth::ManagedAuthenticator
+  def name
+    'vivokey'
+  end
+
+  def can_revoke?
+    SiteSetting.vivokey_openid_allow_association_change
+  end
+
+  def can_connect_existing_user?
+    SiteSetting.vivokey_openid_allow_association_change
+  end
+
+  def enabled?
+    SiteSetting.vivokey_openid_enabled
+  end
+
+  def register_middleware(omniauth)
+    omniauth.provider :vivokey_openid,
+      name: :vivokey,
+      cache: lambda { |key, &blk| Rails.cache.fetch(key, expires_in: 10.minutes, &blk) },
+      error_handler: lambda { |error, message|
+        handlers = SiteSetting.vivokey_openid_error_redirects.split("\n")
+        handlers.each do |row|
+          parts = row.split("|")
+          return parts[1] if message.include? parts[0]
+        end
+        nil
+      },
+      verbose_logger: lambda { |message|
+        return unless SiteSetting.vivokey_openid_verbose_logging
+        Rails.logger.warn("VivoKey OIDC Log: #{message}")
+      },
+      setup: lambda { |env|
+        opts = env['omniauth.strategy'].options
+        opts.deep_merge!(
+          client_id: SiteSetting.vivokey_openid_client_id,
+          client_secret: SiteSetting.vivokey_openid_client_secret,
+          client_options: {
+            discovery_document: SiteSetting.vivokey_openid_discovery_document,
+          },
+          scope: SiteSetting.vivokey_openid_authorize_scope,
+          token_params: {
+            scope: SiteSetting.vivokey_openid_token_scope,
+          }
+        )
+      }
+  end
+
+  def after_authenticate(auth_token, existing_account: nil)
+    result = super(auth_token, existing_account: existing_account)
+
+    # do not consider unverified emails to be valid
+    email_verified = !!auth_token[:extra][:raw_info][:email_verified]
+    result.email_valid &&= email_verified
+
+    result
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -4,59 +4,8 @@
 # authors: David Taylor
 # url: https://github.com/VivoKey/plugin-discourse
 
-require_relative "lib/omniauth_vivokey_open_id"
+require_relative "lib/vivo_key_authenticator"
 
-class VivoKeyAuthenticator < Auth::ManagedAuthenticator
-
-  def name
-    'vivokey'
-  end
-
-  def can_revoke?
-    SiteSetting.vivokey_openid_allow_association_change
-  end
-
-  def can_connect_existing_user?
-    SiteSetting.vivokey_openid_allow_association_change
-  end
-
-  def enabled?
-    SiteSetting.vivokey_openid_enabled
-  end
-
-  def register_middleware(omniauth)
-
-    omniauth.provider :vivokey_openid,
-      name: :vivokey,
-      cache: lambda { |key, &blk| Rails.cache.fetch(key, expires_in: 10.minutes, &blk) },
-      error_handler: lambda { |error, message|
-        handlers = SiteSetting.vivokey_openid_error_redirects.split("\n")
-        handlers.each do |row|
-          parts = row.split("|")
-          return parts[1] if message.include? parts[0]
-        end
-        nil
-      },
-      verbose_logger: lambda { |message|
-        return unless SiteSetting.vivokey_openid_verbose_logging
-        Rails.logger.warn("VivoKey OIDC Log: #{message}")
-      },
-      setup: lambda { |env|
-        opts = env['omniauth.strategy'].options
-        opts.deep_merge!(
-          client_id: SiteSetting.vivokey_openid_client_id,
-          client_secret: SiteSetting.vivokey_openid_client_secret,
-          client_options: {
-            discovery_document: SiteSetting.vivokey_openid_discovery_document,
-          },
-          scope: SiteSetting.vivokey_openid_authorize_scope,
-          token_params: {
-            scope: SiteSetting.vivokey_openid_token_scope,
-          }
-        )
-      }
-  end
-end
 
 # TODO: remove this check once Discourse 2.2 is released
 if Gem.loaded_specs['jwt'].version > Gem::Version.create('2.0')

--- a/spec/lib/vivo_key_authenticator_spec.rb
+++ b/spec/lib/vivo_key_authenticator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../lib/vivo_key_authenticator'
+
+describe VivoKeyAuthenticator do
+  describe '#after_authenticate' do
+    let(:auth_result) { described_class.new.after_authenticate(auth_token) }
+
+    let(:auth_token) do
+      {
+        provider: 'vivokey',
+        uid: '1234',
+        info: {
+          email: 'awesome@example.com'
+        },
+        extra: {
+          raw_info: {
+            email_verified: true
+          }
+        }
+      }
+    end
+
+    describe 'marking email as valid' do
+      context 'when email is verified' do
+        it { expect(auth_result.email_valid).to be true }
+      end
+
+      context 'when email is not verified' do
+        before { auth_token[:extra][:raw_info][:email_verified] = false }
+        it { expect(auth_result.email_valid).to be_falsey }
+      end
+
+      context 'when email verification status is unknown' do
+        before { auth_token[:extra][:raw_info] = {} }
+        it { expect(auth_result.email_valid).to be_falsey }
+      end
+
+      context 'when there is no email' do
+        before do
+          auth_token[:info][:email] = nil
+          auth_token[:extra][:raw_info] = {}
+        end
+
+        it { expect(auth_result.email_valid).to be_falsey }
+      end
+    end
+  end
+end

--- a/spec/lib/vivo_key_authenticator_spec.rb
+++ b/spec/lib/vivo_key_authenticator_spec.rb
@@ -4,47 +4,64 @@ require 'rails_helper'
 require_relative '../../lib/vivo_key_authenticator'
 
 describe VivoKeyAuthenticator do
-  describe '#after_authenticate' do
-    let(:auth_result) { described_class.new.after_authenticate(auth_token) }
+  let(:auth_result) { described_class.new.after_authenticate(auth_token) }
 
-    let(:auth_token) do
-      {
-        provider: 'vivokey',
-        uid: '1234',
-        info: {
-          email: 'awesome@example.com'
-        },
-        extra: {
-          raw_info: {
-            email_verified: true
-          }
+  let(:auth_token) do
+    {
+      provider: 'vivokey',
+      uid: '1234',
+      info: {
+        email: 'awesome@example.com'
+      },
+      extra: {
+        raw_info: {
+          email_verified: true
         }
       }
+    }
+  end
+
+  describe 'marking email as valid' do
+    context 'when email is verified' do
+      it { expect(auth_result.email_valid).to be true }
     end
 
-    describe 'marking email as valid' do
-      context 'when email is verified' do
-        it { expect(auth_result.email_valid).to be true }
+    context 'when email is not verified' do
+      before { auth_token[:extra][:raw_info][:email_verified] = false }
+      it { expect(auth_result.email_valid).to be_falsey }
+    end
+
+    context 'when email verification status is unknown' do
+      before { auth_token[:extra][:raw_info] = {} }
+      it { expect(auth_result.email_valid).to be_falsey }
+    end
+
+    context 'when there is no email' do
+      before do
+        auth_token[:info][:email] = nil
+        auth_token[:extra][:raw_info] = {}
       end
 
-      context 'when email is not verified' do
-        before { auth_token[:extra][:raw_info][:email_verified] = false }
-        it { expect(auth_result.email_valid).to be_falsey }
-      end
+      it { expect(auth_result.email_valid).to be_falsey }
+    end
+  end
 
-      context 'when email verification status is unknown' do
-        before { auth_token[:extra][:raw_info] = {} }
-        it { expect(auth_result.email_valid).to be_falsey }
-      end
+  describe 'account registration' do
+    before { SiteSetting.vivokey_openid_registration = false }
 
-      context 'when there is no email' do
-        before do
-          auth_token[:info][:email] = nil
-          auth_token[:extra][:raw_info] = {}
-        end
+    context 'when account registration is allowed' do
+      before { SiteSetting.vivokey_openid_registration = true }
+      it { expect(auth_result).not_to be_failed }
+    end
 
-        it { expect(auth_result.email_valid).to be_falsey }
-      end
+    context 'when account registration is not allowed' do
+      it { expect(auth_result).to be_failed }
+      it { expect(auth_result.failed_reason).to eq 'Account registration via VivoKey OpenID is not allowed.' }
+    end
+
+    context 'when account registration is not needed' do
+      before { Fabricate(:user, email: auth_token.dig(:info, :email)) }
+      it { expect(auth_result).not_to be_failed }
     end
   end
 end


### PR DESCRIPTION
If claim "email_verified" is available and equals to "true", "email" claim is suggested as a login for new account registration without the need to confirm it:

![verified_email](https://user-images.githubusercontent.com/4718644/60105541-eda0fb80-977c-11e9-9c1e-c9a1ee378334.png)

Otherwise, "email" claim is not suggested and user must specify an email manually and then confirm it:

![unverified_email](https://user-images.githubusercontent.com/4718644/60105600-07424300-977d-11e9-81dd-2ce991e73f34.png)

New setting "vivokey openid registration" is added to control the ability to register accounts via VivoKey OpenID:

![registration_setting](https://user-images.githubusercontent.com/4718644/60105640-19bc7c80-977d-11e9-892a-dda369fb53e0.png)

Default value is false:

![registration_not_allowed](https://user-images.githubusercontent.com/4718644/60105654-1fb25d80-977d-11e9-962b-716ab56cd681.png)
