### PR TITLE
#5 Hard code and hide settings

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,10 +2,8 @@ en:
   site_settings:
     vivokey_openid_enabled: Enable VivoKey OpenID authentication. Customize user interface text <a href='%{base_path}/admin/customize/site_texts?q=js.login.vivokey'>here</a>
     vivokey_openid_registration: "Enable new account registration"
-    vivokey_openid_discovery_document: "VivoKey OpenID discovery document URL. Normally located at 'https://your.domain/.well-known/openid-configuration'"
     vivokey_openid_client_id: "VivoKey OpenID client ID"
     vivokey_openid_client_secret: "VivoKey OpenID client secret"
-    vivokey_openid_authorize_scope: "The scopes sent to the authorize endpoint. This must include 'openid'."
     vivokey_openid_token_scope: "The scopes sent when requesting the token endpoint. The official specification does not require this."
     vivokey_openid_error_redirects: "If the callback error_reason contains the first parameter, the user will be redirected to the URL in the second parameter"
     vivokey_openid_allow_association_change: "Allow users to disconnect and reconnect their Discourse accounts from the VivoKey OpenID provider"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,16 +3,12 @@ plugins:
     default: false
   vivokey_openid_registration:
     default: false
-  vivokey_openid_discovery_document:
-    default: ""
   vivokey_openid_client_id:
     default: ""
   vivokey_openid_client_secret:
     default: ""
   vivokey_openid_allow_association_change:
     default: false
-  vivokey_openid_authorize_scope:
-    default: "openid"
   vivokey_openid_verbose_logging:
     default: false
   vivokey_openid_token_scope:

--- a/lib/vivo_key_authenticator.rb
+++ b/lib/vivo_key_authenticator.rb
@@ -1,6 +1,9 @@
 require_relative "omniauth_vivokey_open_id"
 
 class VivoKeyAuthenticator < Auth::ManagedAuthenticator
+  VIVOKEY_OPENID_DISCOVERY_DOCUMENT = 'https://api.vivokey.com/openid/.well-known/openid-configuration'
+  VIVOKEY_OPENID_AUTHORIZE_SCOPE = 'openid email'
+
   def name
     'vivokey'
   end
@@ -39,9 +42,9 @@ class VivoKeyAuthenticator < Auth::ManagedAuthenticator
           client_id: SiteSetting.vivokey_openid_client_id,
           client_secret: SiteSetting.vivokey_openid_client_secret,
           client_options: {
-            discovery_document: SiteSetting.vivokey_openid_discovery_document,
+            discovery_document: VIVOKEY_OPENID_DISCOVERY_DOCUMENT,
           },
-          scope: SiteSetting.vivokey_openid_authorize_scope,
+          scope: VIVOKEY_OPENID_AUTHORIZE_SCOPE,
           token_params: {
             scope: SiteSetting.vivokey_openid_token_scope,
           }


### PR DESCRIPTION
Settings **vivokey openid discovery document** and **vivokey openid authorize scope** are hidden

![settings_hidden](https://user-images.githubusercontent.com/4718644/60207727-00482d00-9870-11e9-941e-6abdd567da65.png)

and their values are hardcoded as follows:

`vivokey_openid_discovery_document = https://api.vivokey.com/openid/.well-known/openid-configuration`

`vivokey_openid_authorize_scope = openid email`