### PR TITLE
#3 Make email field editable when matching by email is disabled

### DIFF
--- a/lib/vivo_key_authenticator.rb
+++ b/lib/vivo_key_authenticator.rb
@@ -69,6 +69,15 @@ class VivoKeyAuthenticator < Auth::ManagedAuthenticator
       result.failed_reason = I18n.t("vivokey_openid.registration_not_allowed")
     end
 
+    # If logged in with email taken by another user
+    if result.user.nil? && (user = User.find_by_email(auth_token.dig(:info, :email)))
+      # and matching by email is disabled
+      unless match_by_email
+        # mark email as invalid
+        result.email_valid = false
+      end
+    end
+
     result
   end
 end

--- a/spec/lib/vivo_key_authenticator_spec.rb
+++ b/spec/lib/vivo_key_authenticator_spec.rb
@@ -71,6 +71,7 @@ describe VivoKeyAuthenticator do
   it 'matching by email is disabled' do
     Fabricate(:user, email: auth_token.dig(:info, :email))
     expect(auth_result.user).to be_nil
+    expect(auth_result.email_valid).to be false
   end
 
   it 'but connecting existing account is not' do


### PR DESCRIPTION
Dynamic account linking is disabled in #6. When a user authenticates with VivoKey and it's email claim matches to the existing account, the user is offered to enter some other (not taken) email to complete account registration.  "Email" field is not editable which is wrong. This PR makes it editable.