### PR TITLE
Allow users to connect to VK but not disconnect from it

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,7 +6,8 @@ en:
     vivokey_openid_client_secret: "VivoKey OpenID client secret"
     vivokey_openid_token_scope: "The scopes sent when requesting the token endpoint. The official specification does not require this."
     vivokey_openid_error_redirects: "If the callback error_reason contains the first parameter, the user will be redirected to the URL in the second parameter"
-    vivokey_openid_allow_association_change: "Allow users to disconnect and reconnect their Discourse accounts from the VivoKey OpenID provider"
+    vivokey_openid_allow_connect: "Allow users to connect their Discourse accounts to the VivoKey OpenID provider"
+    vivokey_openid_allow_disconnect: "Allow users to disconnect their Discourse accounts from the VivoKey OpenID provider"
     vivokey_openid_verbose_logging: "Log detailed VivoKey OpenID authentication information to `/logs`. Keep this disabled during normal use."
   vivokey_openid:
     registration_not_allowed: "Account registration via VivoKey OpenID is not allowed."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,7 +7,9 @@ plugins:
     default: ""
   vivokey_openid_client_secret:
     default: ""
-  vivokey_openid_allow_association_change:
+  vivokey_openid_allow_connect:
+    default: true
+  vivokey_openid_allow_disconnect:
     default: false
   vivokey_openid_verbose_logging:
     default: false

--- a/lib/vivo_key_authenticator.rb
+++ b/lib/vivo_key_authenticator.rb
@@ -9,11 +9,11 @@ class VivoKeyAuthenticator < Auth::ManagedAuthenticator
   end
 
   def can_revoke?
-    SiteSetting.vivokey_openid_allow_association_change
+    SiteSetting.vivokey_openid_allow_disconnect
   end
 
   def can_connect_existing_user?
-    SiteSetting.vivokey_openid_allow_association_change
+    SiteSetting.vivokey_openid_allow_connect
   end
 
   def enabled?

--- a/spec/lib/vivo_key_authenticator_spec.rb
+++ b/spec/lib/vivo_key_authenticator_spec.rb
@@ -75,7 +75,7 @@ describe VivoKeyAuthenticator do
   end
 
   it 'but connecting existing account is not' do
-    SiteSetting.vivokey_openid_allow_association_change = true
+    SiteSetting.vivokey_openid_allow_connect = true
     user = Fabricate(:user, email: auth_token.dig(:info, :email))
 
     auth_result = described_class.new.after_authenticate(auth_token, existing_account: user)


### PR DESCRIPTION
Splits `vivokey openid allow association change`  setting into 
- `vivokey openid allow connect` (default: true)
- `vivokey openid allow disconnect` (default: false)

![split](https://user-images.githubusercontent.com/4718644/61057045-f1d04880-a40d-11e9-9c8e-c9cb8605c3f9.png)
