### PR TITLE
Allow VivoKey registration even when invite only

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -10,3 +10,34 @@ en:
     vivokey_openid_verbose_logging: "Log detailed VivoKey OpenID authentication information to `/logs`. Keep this disabled during normal use."
   vivokey_openid:
     registration_not_allowed: "Account registration via VivoKey OpenID is not allowed."
+
+  vivokey:
+    forgot_password:
+      title: "Forgot Password"
+      subject_template: "[%{email_prefix}] Password reset"
+      text_body_template: |
+        Somebody asked to reset your password on [%{site_name}](%{base_url}).
+
+        If it was not you, you can safely ignore this email.
+
+        You cannot request a new password. You must log in using your VivoKey.
+
+    set_password:
+      title: "Set Password"
+      subject_template: "[%{email_prefix}] Set Password"
+      text_body_template: |
+        Somebody asked to add a password to your account on [%{site_name}](%{base_url}).
+
+        If you did not make this request, you can safely ignore this email.
+
+        You cannot request a password. You must log in using your VivoKey.
+
+    email_login:
+      title: "Log in via link"
+      subject_template: "[%{email_prefix}] Log in via link"
+      text_body_template: |
+        Someone requested a log in at [%{site_name}](%{base_url}).
+
+        If you did not request this link, you can safely ignore this email.
+
+        You cannot request a log in link. You must log in using your VivoKey.

--- a/lib/vivokey/extensions/disable_local_logins.rb
+++ b/lib/vivokey/extensions/disable_local_logins.rb
@@ -1,0 +1,45 @@
+module VivoKey
+  module Extensions
+    module DisableLocalLoginsForAccountsConnectedToVivoKey
+      HINT = 'You must log in using your VivoKey.'.freeze
+
+      module SessionController
+        protected
+
+        def login(user)
+          unless user.user_associated_accounts.where(provider_name: 'vivokey').exists?
+            return super
+          end
+
+          return render json: failed_json.merge(error: HINT)
+        end
+      end
+
+      module UserNotifications
+        def forgot_password(user, opts = {})
+          if user.user_associated_accounts.where(provider_name: 'vivokey').exists?
+            build_email(
+              user.email,
+              template: user.has_password? ? "vivokey.forgot_password" : "vivokey.set_password",
+              locale: user_locale(user)
+            )
+          else
+            super(user, opts)
+          end
+        end
+
+        def email_login(user, opts = {})
+          if user.user_associated_accounts.where(provider_name: 'vivokey').exists?
+            build_email(
+              user.email,
+              template: "vivokey.email_login",
+              locale: user_locale(user)
+            )
+          else
+            super(user, opts)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vivokey/extensions/relax_invite_only.rb
+++ b/lib/vivokey/extensions/relax_invite_only.rb
@@ -1,0 +1,42 @@
+module VivoKey
+  module Extensions
+    module RelaxInviteOnly
+      AUTHENTICATOR_NAME = 'vivokey'.freeze
+
+      module Users
+        module OmniauthCallbacksController
+          protected
+
+          def complete_response_data
+            is_vivokey = @auth_result.session_data.present? &&
+              @auth_result.session_data[:authenticator_name] == AUTHENTICATOR_NAME
+
+            if @auth_result.user
+              user_found(@auth_result.user)
+            elsif SiteSetting.invite_only? && !is_vivokey
+              @auth_result.requires_invite = true
+            else
+              session[:authentication] = @auth_result.session_data
+            end
+          end
+        end
+      end
+
+      module UsersController
+        private
+
+        def suspicious?(params)
+          is_suspicious = super(params)
+          return is_suspicious unless vivokey?
+
+          is_suspicious && honeypot_or_challenge_fails?(params)
+        end
+
+        def vivokey?
+          session.present? && session[:authentication].present? &&
+            session[:authentication][:authenticator_name] == AUTHENTICATOR_NAME
+        end
+      end
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -10,6 +10,28 @@ register_svg_icon 'vivokey' if respond_to?(:register_svg_icon)
 
 register_asset 'stylesheets/vivokey-login.scss'
 
+after_initialize do
+  require_relative 'lib/vivokey/extensions/relax_invite_only'
+  require_relative 'lib/vivokey/extensions/disable_local_logins'
+
+  Users::OmniauthCallbacksController.prepend(
+    VivoKey::Extensions::RelaxInviteOnly::Users::OmniauthCallbacksController
+  )
+
+  UsersController.prepend(
+    VivoKey::Extensions::RelaxInviteOnly::UsersController
+  )
+
+  SessionController.prepend(
+    VivoKey::Extensions::DisableLocalLoginsForAccountsConnectedToVivoKey::SessionController
+  )
+
+  UserNotifications.prepend(
+    VivoKey::Extensions::DisableLocalLoginsForAccountsConnectedToVivoKey::UserNotifications
+  )
+end
+
+
 # TODO: remove this check once Discourse 2.2 is released
 if Gem.loaded_specs['jwt'].version > Gem::Version.create('2.0')
   auth_provider authenticator: VivoKeyAuthenticator.new(),

--- a/spec/lib/vivokey/extensions/session_controller_spec.rb
+++ b/spec/lib/vivokey/extensions/session_controller_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe SessionController, type: :controller do
+  describe '#create' do
+    let(:user) { Fabricate(:user) }
+
+    describe 'by username' do
+      before do
+        token = user.email_tokens.find_by(email: user.email)
+        EmailToken.confirm(token.token)
+      end
+
+      it 'logs in' do
+        events = DiscourseEvent.track_events do
+          post :create, params: {
+            login: user.username, password: 'myawesomepassword'
+          }, format: :json
+        end
+
+        expect(response.status).to eq(200)
+        expect(events.map { |event| event[:event_name] }).to contain_exactly(
+          :user_logged_in, :user_first_logged_in
+        )
+
+        user.reload
+
+        expect(session[:current_user_id]).to eq(user.id)
+        expect(user.user_auth_tokens.count).to eq(1)
+        expect(UserAuthToken.hash_token(cookies[:_t])).to eq(user.user_auth_tokens.first.auth_token)
+      end
+
+      context 'when user is linked to VivoKey' do
+        before do
+          UserAssociatedAccount.create!(
+            user: user,
+            provider_name: 'vivokey',
+            provider_uid: 'uid'
+          )
+        end
+
+        it 'does not log in' do
+          events = DiscourseEvent.track_events do
+            post :create, params: {
+              login: user.username, password: 'myawesomepassword'
+            }, format: :json
+          end
+
+          expect(session[:current_user_id]).to be_nil
+
+          expect(response.status).to eq(200)
+          expect(JSON.parse(response.body)['error']).to eq(
+            "You must log in using your VivoKey."
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/vivokey/extensions/user_notifications_spec.rb
+++ b/spec/lib/vivokey/extensions/user_notifications_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+describe UserNotifications do
+  let(:user) { Fabricate(:admin) }
+
+  describe '.forgot_password' do
+    subject { UserNotifications.forgot_password(user, email_token: 'token') }
+
+    context 'when user has password' do
+      it 'sends password reset link' do
+        expect(subject.to).to eq([user.email])
+        expect(subject.subject).to eq '[Discourse] Password reset'
+        expect(subject.from).to eq([SiteSetting.notification_email])
+        expect(subject.body).to include('token')
+      end
+    end
+
+    context 'when user does not have a password' do
+      let(:user) { Fabricate(:admin, password: nil) }
+
+      it 'sends password set link' do
+        expect(subject.to).to eq([user.email])
+        expect(subject.subject).to eq '[Discourse] Set Password'
+        expect(subject.from).to eq([SiteSetting.notification_email])
+        expect(subject.body).to include('token')
+      end
+    end
+
+    context 'when user is linked to VivoKey' do
+      before do
+        UserAssociatedAccount.create!(
+          user: user,
+          provider_name: 'vivokey',
+          provider_uid: 'uid'
+        )
+      end
+
+      context 'when user has password' do
+        it 'sends "You must log in using your VivoKey."' do
+          expect(subject.to).to eq([user.email])
+          expect(subject.subject).to eq '[Discourse] Password reset'
+          expect(subject.from).to eq([SiteSetting.notification_email])
+
+          expect(subject.body).not_to include('token')
+          expect(subject.body).to include('You must log in using your VivoKey.')
+        end
+      end
+
+      context 'when user does not have a password' do
+        let(:user) { Fabricate(:admin, password: nil) }
+
+        it 'sends "You must log in using your VivoKey."' do
+          expect(subject.to).to eq([user.email])
+          expect(subject.subject).to eq '[Discourse] Set Password'
+          expect(subject.from).to eq([SiteSetting.notification_email])
+
+          expect(subject.body).not_to include('token')
+          expect(subject.body).to include('You must log in using your VivoKey.')
+        end
+      end
+    end
+  end
+
+  describe '.email_login' do
+    subject { UserNotifications.email_login(user, email_token: 'token') }
+
+    it 'sends login link' do
+      expect(subject.to).to eq([user.email])
+      expect(subject.subject).to eq '[Discourse] Log in via link'
+      expect(subject.from).to eq([SiteSetting.notification_email])
+      expect(subject.body).to include('token')
+    end
+
+    context 'when user is linked to VivoKey' do
+      before do
+        UserAssociatedAccount.create!(
+          user: user,
+          provider_name: 'vivokey',
+          provider_uid: 'uid'
+        )
+      end
+
+      it 'sends "You must log in using your VivoKey."' do
+        expect(subject.to).to eq([user.email])
+        expect(subject.subject).to eq '[Discourse] Log in via link'
+        expect(subject.from).to eq([SiteSetting.notification_email])
+
+        expect(subject.body).not_to include('token')
+        expect(subject.body).to include('You must log in using your VivoKey.')
+      end
+    end
+  end
+end

--- a/spec/lib/vivokey/extensions/users_controller_spec.rb
+++ b/spec/lib/vivokey/extensions/users_controller_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+describe UsersController, type: :controller do
+  let(:user) { Fabricate(:user) }
+
+  describe '#create' do
+    def honeypot_magic(params)
+      get '/u/hp.json'
+      json = JSON.parse(response.body)
+      params[:password_confirmation] = json["value"]
+      params[:challenge] = json["challenge"].reverse
+      params
+    end
+
+    before do
+      UsersController.any_instance.stubs(:honeypot_value).returns(nil)
+      UsersController.any_instance.stubs(:challenge_value).returns(nil)
+      SiteSetting.allow_new_registrations = true
+      @user = Fabricate.build(:user, password: "strongpassword")
+    end
+
+    let(:post_user_params) do
+      { name: @user.name,
+        username: @user.username,
+        password: "strongpassword",
+        email: @user.email }
+    end
+
+    def post_user
+      post "/u.json", params: post_user_params
+    end
+
+    context "when 'invite only' setting is enabled" do
+      before { SiteSetting.invite_only = true }
+
+      let(:create_params) { {
+        name: @user.name,
+        username: @user.username,
+        password: 'strongpassword',
+        email: @user.email
+      }}
+
+      context 'when user is not linked to VivoKey' do
+        before do
+          described_class.any_instance.stubs(:vivokey?).returns(false)
+        end
+
+        it 'should not create a new user' do
+          expect {
+            post :create, params: create_params, format: :json
+          }.to_not change { User.count }
+
+          expect(response.status).to eq(200)
+        end
+
+        it 'should not send an email' do
+          User.any_instance.expects(:enqueue_welcome_message).never
+          post :create, params: create_params, format: :json
+          expect(response.status).to eq(200)
+        end
+
+        it 'should say it was successful' do
+          post :create, params: create_params, format: :json
+          json = JSON::parse(response.body)
+          expect(response.status).to eq(200)
+          expect(json["success"]).to eq(true)
+
+          # should not change the session
+          expect(session["user_created_message"]).to be_blank
+          expect(session[SessionController::ACTIVATE_USER_KEY]).to be_blank
+        end
+      end
+
+      context 'when user is linked to VivoKey' do
+        before do
+          described_class.any_instance.stubs(:vivokey?).returns(true)
+        end
+
+        it 'should create a new user' do
+          expect {
+            post :create, params: create_params, format: :json
+          }.to change { User.count }.by(1)
+
+          expect(response.status).to eq(200)
+        end
+
+        it 'should say it was successful' do
+          post :create, params: create_params, format: :json
+          json = JSON::parse(response.body)
+          expect(response.status).to eq(200)
+          expect(json["success"]).to eq(true)
+
+          expect(session["user_created_message"]).not_to be_blank
+          expect(session[SessionController::ACTIVATE_USER_KEY]).not_to be_blank
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. Allow VivoKey registration even when "invite only" is enabled.
2. Block username/password authentications for accounts linked to VivoKey.

![username_login](https://user-images.githubusercontent.com/4718644/61060147-88ebcf00-a413-11e9-9ce7-fdc8db1965a5.png)

In the case of "I forgot my password" and "with email" an email is sent but contains "You must log in using your VivoKey" instead of a login link.  